### PR TITLE
Add delay before customize button use

### DIFF
--- a/src/metrics.py
+++ b/src/metrics.py
@@ -25,6 +25,7 @@ async def scrape_store_metrics(page: Page, store_info: dict) -> dict | None:
 
         customise_btn = page.locator("#content span:has-text('Customised')").nth(0)
         await expect(customise_btn).to_be_visible(timeout=WAIT_TIMEOUT)
+        await page.wait_for_timeout(5000)
         await expect(customise_btn).to_be_enabled(timeout=WAIT_TIMEOUT)
         await customise_btn.click(timeout=ACTION_TIMEOUT)
         await expect(page.locator("kat-date-range-picker")).to_be_visible(timeout=WAIT_TIMEOUT)


### PR DESCRIPTION
## Summary
- wait 5 seconds after the "Customised" button appears before interacting

## Testing
- `python3 -m py_compile scraper.py src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688920f971148321b68f07252b70d1d3